### PR TITLE
Add explicit `HostPortWaitStrategy` waiting strategy

### DIFF
--- a/src/main/java/com/github/sabomichal/jooq/PostgresDDLDatabase.java
+++ b/src/main/java/com/github/sabomichal/jooq/PostgresDDLDatabase.java
@@ -21,6 +21,7 @@ import org.testcontainers.utility.DockerImageName;
 
 
 import static org.jooq.tools.StringUtils.isBlank;
+import static org.testcontainers.containers.wait.strategy.Wait.forListeningPort;
 
 
 /**
@@ -67,7 +68,8 @@ public class PostgresDDLDatabase extends PostgresDatabase {
                 postgresContainer = new PostgreSQLContainer<>(dockerImageName)
                     .withDatabaseName("jooqdb")
                     .withUsername("user")
-                    .withPassword("pwd");
+                    .withPassword("pwd")
+                    .waitingFor(forListeningPort());
                 postgresContainer.start();
 
                 Properties info = new Properties();


### PR DESCRIPTION
## What

Added an explicit `HostPortWaitStrategy` waiting strategy to the `PostgreSQLContainer`.

## Why

When using the plugin on `macos 13.x` with `Colima` version `0.4.x` and `0.5.x` for testing, connections to the PostgreSQL container often fail because they are attempted while the container is not ready yet. Applying the `HostPortWaitStrategy` waiting strategy resolves the problem.