### PR TITLE
allow control over PostgreSQL transactional locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Used directly as the Flyway locations property. Comma-separated list of location
 Custom Docker image name used as compatible substitute for default image name "postgres:14".
 #### placeholders
 Used as the Flyway placeholders property. Comma-separated list of key-value pairs in a form of "key=value". Defaults to empty map.
+#### flyway.postgresql.transactional.lock
+Boolean flag for enabling or disabling the `PostgreSQL` transactional locks, which were enabled by default in `flyway-core` version `9.1.2` and higher.
+See https://github.com/flyway/flyway/issues/3492 for more details. Defaults to `true`
 ### Maven
 Simply add the meta plugin as a dependency to jOOQ codegen maven plugin. The following example demonstrates the usage.
 ```xml
@@ -47,6 +50,8 @@ Simply add the meta plugin as a dependency to jOOQ codegen maven plugin. The fol
                                 <value>postgres:14</value>
                                 <key>placeholders</key>
                                 <value>a=1,b=2</value>
+                                <key>flyway.postgresql.transactional.lock</key>
+                                <value>true</value>
                             </property>
                         </properties>
                         <includes>public.*</includes>

--- a/src/main/java/com/github/sabomichal/jooq/PostgresDDLDatabase.java
+++ b/src/main/java/com/github/sabomichal/jooq/PostgresDDLDatabase.java
@@ -42,6 +42,7 @@ public class PostgresDDLDatabase extends PostgresDatabase {
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("postgres");
     private static final String DEFAULT_TAG = "14";
     private static final String KEY_VALUE_SEPARATOR = "=";
+    private static final String FLYWAY_POSTGRESQL_TRANSACTIONAL_LOCK = "flyway.postgresql.transactional.lock";
 
     private Connection connection;
     private PostgreSQLContainer<?> postgresContainer;
@@ -100,7 +101,12 @@ public class PostgresDDLDatabase extends PostgresDatabase {
                 if (isBlank(defaultSchema)) {
                     defaultSchema = "public";
                 }
+
+                Map<String, String> flywayConfigProperties = Map.of(
+                        FLYWAY_POSTGRESQL_TRANSACTIONAL_LOCK, getProperties().getProperty(FLYWAY_POSTGRESQL_TRANSACTIONAL_LOCK, "true"));
+
                 Flyway.configure()
+                    .configuration(flywayConfigProperties)
                     .dataSource(postgresContainer.getJdbcUrl(), postgresContainer.getUsername(), postgresContainer.getPassword())
                     .locations(locations)
                     .schemas(defaultSchema)


### PR DESCRIPTION
## What

It is now possible to control the PostreSQL transactional locks, enabled by default since `flyway-core` version `9.1.2`, via the `flyway.postgresql.transactional.lock` configuration property. 

## Why

Enabling the transactional locks can cause issues during migrations - see https://github.com/flyway/flyway/issues/3492 and https://github.com/flyway/flyway/issues/3508 for more details. The default is set to `true` to preserve the current behaviour.